### PR TITLE
Set a `sass`property in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "Set of common UI patterns/styles for hof projects",
   "main": "index.js",
+  "sass": "assets/stylesheets/app.scss",
   "scripts": {
     "postinstall": "./build",
     "test-client": "./node_modules/karma/bin/karma start ./test/client/karma.conf.js",


### PR DESCRIPTION
This allows projects which are using `npm-sass` to do sass compilation to pick up the location of the main sass file without having to specify the full path.

See https://www.npmjs.com/package/npm-sass#imports