### PR TITLE
Allow default list styles

### DIFF
--- a/assets/stylesheets/govuk-elements/_lists.scss
+++ b/assets/stylesheets/govuk-elements/_lists.scss
@@ -3,7 +3,6 @@
 
 ul,
 ol {
-  list-style-type: none;
   padding: 0;
 }
 
@@ -33,3 +32,9 @@ ol {
   margin-bottom: 5px;
 }
 
+ul {
+  @extend .list-bullet;
+}
+ol {
+  @extend .list-number;
+}


### PR DESCRIPTION
`ul` and `ol` elements with no class should inherit default styles for their usage rather than being fully unstyled.

This makes rendering markdown content in apps easier as markdown generated lists will always be un-className-ed.