### PR TITLE
Remove underscore dependency

### DIFF
--- a/assets/javascript/form-focus.js
+++ b/assets/javascript/form-focus.js
@@ -8,7 +8,8 @@
 
 'use strict';
 
-var _ = require('underscore');
+var each = require('lodash.foreach');
+var groupBy = require('lodash.groupby');
 
 var NAME = 'form-focus';
 
@@ -28,7 +29,7 @@ function blurred(e) {
 
 function clicked(e, target) {
     target = target || helpers.target(e);
-    _.each(groups[target.name], function (input) {
+    each(groups[target.name], function (input) {
         if (input.checked) {
             helpers.addClass(input.parentNode, selectedClass);
         } else {
@@ -56,7 +57,7 @@ function bindSummaryEvents(summary) {
 }
 
 function setupLabels(labels) {
-    groups = _.groupBy(document.getElementsByTagName('input'), 'name');
+    groups = groupBy(document.getElementsByTagName('input'), 'name');
     for (var i = 0, len = labels.length; i < len; i++) {
         helpers.once(labels[i], NAME, bindInputEvents);
     }

--- a/assets/javascript/helpers.js
+++ b/assets/javascript/helpers.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var _ = require('underscore');
+var each = require('lodash.foreach');
 
 var DESKTOP_WIDTH = 769;
 
@@ -88,7 +88,7 @@ helpers.addClass = function (el, className) {
 };
 
 helpers.addClasses = function (el, classNames) {
-    _.each(classNames, function (className) {
+    each(classNames, function (className) {
         helpers.addClass(el, className);
     });
 };
@@ -120,7 +120,7 @@ helpers.getElementsByClass = function (parent, tag, className) {
         return parent.getElementsByClassName(className);
     } else {
         var elems = [];
-        _.each(parent.getElementsByTagName(tag), function (t) {
+        each(parent.getElementsByTagName(tag), function (t) {
             if (helpers.hasClass(t, className)) {
                 elems.push(t);
             }

--- a/assets/javascript/progressive-reveal.js
+++ b/assets/javascript/progressive-reveal.js
@@ -1,6 +1,7 @@
 'use strict';
 
-var _ = require('underscore');
+var each = require('lodash.foreach');
+var groupBy = require('lodash.groupby');
 
 var helpers = require('./helpers'),
     inputs, groups,
@@ -10,7 +11,7 @@ var helpers = require('./helpers'),
 function inputClicked(e, target) {
     target = target || helpers.target(e);
     var shown;
-    _.each(groups[target.name], function (input) {
+    each(groups[target.name], function (input) {
         var id = input.getAttribute('aria-controls');
         var toggle = document.getElementById(id);
         if (toggle) {
@@ -53,7 +54,7 @@ function progressiveReveal() {
 
     if (forms.length > 0) {
         inputs = document.getElementsByTagName('input');
-        groups = _.groupBy(inputs, 'name');
+        groups = groupBy(inputs, 'name');
         for (var i = 0, num = inputs.length; i < num; i++) {
             input = inputs[i];
             if (input.type.match(/radio|checkbox/)) {

--- a/assets/javascript/validation.js
+++ b/assets/javascript/validation.js
@@ -1,4 +1,4 @@
-var _ = require('underscore');
+var each = require('lodash.foreach');
 
 var helpers = require('./helpers');
 
@@ -40,7 +40,7 @@ function setup(summary) {
 
     var errors = summary.getElementsByTagName('a');
 
-    _.each(errors, function (error) {
+    each(errors, function (error) {
         helpers.addEvent(error, 'click', clicked);
         helpers.addEvent(error, 'keydown', pressed);
     });

--- a/package.json
+++ b/package.json
@@ -24,8 +24,9 @@
     "async": "^0.9.0",
     "browserify": "^4.0.0",
     "govuk_frontend_toolkit": "^4.5.0",
-    "mustache": "^1.1.0",
-    "underscore": "^1.8.3"
+    "lodash.foreach": "^4.5.0",
+    "lodash.groupby": "^4.6.0",
+    "mustache": "^1.1.0"
   },
   "devDependencies": {
     "jquery": "^2.1.4",

--- a/test/client/lib/util.js
+++ b/test/client/lib/util.js
@@ -1,5 +1,3 @@
-var _ = require('underscore');
-
 module.exports = {
     triggerEvent: function triggerEvent(element, event) {
         var evt = document.createEvent('Event');
@@ -11,7 +9,7 @@ module.exports = {
         options = options || {};
         var evt = document.createEvent('Event');
         evt.initEvent(event, true, true);
-        _.extend(evt, options);
+        Object.assign(evt, options);
         element.dispatchEvent(evt);
     }
 };


### PR DESCRIPTION
There's no need to load in *all* of uderscore when we only ever use two functions.

Instead use the granular lodash modules to pick the two functions we want.