### PR TITLE
Remove mixins.scss from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 node_modules
 assets/stylesheets/*.css
-assets/stylesheets/mixins.scss
 assets/images/icons

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
-  - "0.10"
-  - "0.12"
+  - 4
+  - 6
+  - 7
 notifications:
   email: false


### PR DESCRIPTION
This file used to be compiled, so was ignored. It's not compiled anymore so needs to be unignored.

The file is in version control currently, but gitignore is also used on npm publish, so the file isn't included in the npm bundle, and so compiling the sass of the installed package fails due to a missing file.