### PR TITLE
Remove styling bound to `#content`

### DIFF
--- a/assets/stylesheets/_layout.scss
+++ b/assets/stylesheets/_layout.scss
@@ -5,7 +5,7 @@
     }
 }
 
-#content {
+.main {
     @extend %site-width-container;
     padding-bottom: $gutter;
     @include media(desktop) {


### PR DESCRIPTION
The `#content` container denotes the target of the "skip to main content" link in the govuk template, and so is a functional id. It should not also be used to apply structural style to the page as this means it cannot be moved to other positions to better reflect its functionality.

Instead use the `.main` class which exists on the same container (at present) to apply the structural styling.