### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,12 +27,12 @@
   },
   "devDependencies": {
     "jquery": "^2.1.4",
-    "karma": "0.12.24",
+    "karma": "^1.7.0",
     "karma-browserify": "0.2.1",
     "karma-chai": "0.1.0",
     "karma-cli": "^1.0.1",
-    "karma-mocha": "0.1.9",
-    "karma-phantomjs-launcher": "0.1.4",
+    "karma-mocha": "^1.3.0",
+    "karma-phantomjs-launcher": "^1.0.4",
     "karma-sinon-chai": "0.3.0",
     "mocha": "^3.3.0",
     "npm-sass": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "karma-mocha": "0.1.9",
     "karma-phantomjs-launcher": "0.1.4",
     "karma-sinon-chai": "0.3.0",
+    "mocha": "^3.3.0",
     "npm-sass": "^2.0.0"
   }
 }


### PR DESCRIPTION
Build is currently failing on master because the versions of karma things were waaaaay old and so fail on latest node versions.

Update the things. Make the red go green.