### PR TITLE
feat: add new script to improve accessibility for textarea maxlength

### DIFF
--- a/assets/javascript/character-count.js
+++ b/assets/javascript/character-count.js
@@ -1,0 +1,88 @@
+'use strict';
+
+var helpers = require('./helpers');
+
+CharacterCount.prototype.updateCount = function() {
+  var currentLength = this.$textarea.value.length;
+  var characterNoun = ' characters';
+  var remainderSuffix = ' remaining';
+
+  if (this.maxLength - currentLength === 1 || currentLength - this.maxLength === 1) {
+    characterNoun = ' character';
+  }
+
+  if (this.maxLength - currentLength < 0) {
+    remainderSuffix = ' too many';
+  }
+
+  this.$maxlengthHint.innerHTML = 'You have ' + Math.abs(this.maxLength - currentLength).toString() + characterNoun + remainderSuffix;
+
+  if (currentLength >= this.maxLength + 1) {
+    helpers.removeClass(this.$maxlengthHint, 'form-hint');
+    helpers.addClass(this.$maxlengthHint, 'error-message');
+    helpers.addClass(this.$textarea, 'textarea-error');
+  } else {
+    helpers.addClass(this.$maxlengthHint, 'form-hint');
+    helpers.removeClass(this.$maxlengthHint, 'error-message');
+    helpers.removeClass(this.$textarea, 'textarea-error');
+  }
+};
+
+CharacterCount.prototype.checkIfLengthChanged = function () {
+  if (this.$textarea.length !== this.oldLength) {
+    this.updateCount();
+    this.oldLength = this.$textarea.value.length;
+  }
+};
+
+CharacterCount.prototype.handleFocus = function () {
+  this.lengthChecker = setInterval(this.checkIfLengthChanged.bind(this), 1000);
+};
+
+CharacterCount.prototype.handleBlur = function () {
+  clearInterval(this.lengthChecker);
+};
+
+CharacterCount.prototype.init = function() {
+
+  // Updates hint to js-enabled message
+  this.$maxlengthHint.innerHTML = 'You have ' + this.maxLength.toString() + ' characters remaining';
+
+  // remove maxLength restriction on element
+  this.$textarea.removeAttribute('maxlength');
+
+  // set change event on textarea
+  helpers.addEvent(this.$textarea, 'input', this.updateCount.bind(this));
+  // some assistive technologies do not trigger input events when entering text into fields
+  // add polling functions to check if input length has changed in these circumstances
+  helpers.addEvent(this.$textarea, 'focus', this.handleFocus.bind(this));
+  helpers.addEvent(this.$textarea, 'blur', this.handleBlur.bind(this));
+};
+
+function CharacterCount($textarea) {
+  // passes in textarea and attaches to object
+  this.$textarea = $textarea;
+
+  // attaches hint to object
+  this.$maxlengthHint = document.querySelector('[id=' + this.$textarea.id + '-maxlength-hint]');
+
+  // set maxlength to variable
+  this.maxLength = parseInt(this.$textarea.getAttribute('maxlength'));
+
+  // save old length for polling comparison
+  this.oldLength = 0;
+}
+
+function characterCountAll() {
+  // find all textareas
+  var $allTextAreas = document.getElementsByTagName('textarea');
+
+  // for each textarea if it has maxlength create new characterCount object
+  for (var i = 0; i < $allTextAreas.length; i++) {
+    if ($allTextAreas[i].hasAttribute('maxlength')) {
+      new CharacterCount($allTextAreas[i]).init();
+    }
+  }
+}
+
+module.exports = characterCountAll;

--- a/index.js
+++ b/index.js
@@ -5,5 +5,6 @@ module.exports = {
     validation: require('./assets/javascript/validation'),
     detailsSummary: function() {
         require('./assets/javascript/vendor/details.polyfill')
-    }
+    },
+    characterCount: require('./assets/javascript/character-count')
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hof-frontend-toolkit",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hof-frontend-toolkit",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Set of common UI patterns/styles for hof projects",
   "main": "index.js",
   "sass": "assets/stylesheets/app.scss",

--- a/test/client/spec/index.js
+++ b/test/client/spec/index.js
@@ -14,5 +14,6 @@ describe('hmpo', function () {
     require('./spec.form-focus');
     require('./spec.progressive-reveal');
     require('./spec.validation');
+    require('./spec.character-count');
 
 });

--- a/test/client/spec/spec.character-count.js
+++ b/test/client/spec/spec.character-count.js
@@ -1,0 +1,130 @@
+var characterCount = require('../../../index').characterCount,
+  util = require('../lib/util'),
+  $ = require('jquery');
+
+describe('character-count', function () {
+
+  beforeEach(function () {
+    $('#test-container').append($('<form />'));
+  });
+
+  it('exports a function', function () {
+    characterCount.should.be.a('function');
+  });
+
+  describe('initialisation', function () {
+
+    beforeEach(function () {
+      $('form').append($('<div id="test-group"><textarea name="test" id="test" class="maxlength" maxlength="50"></textarea><span id="test-maxlength-hint" class="form-hint">50 maximum characters</span></div>'));
+    });
+
+    it('should change the static character count message if the textarea has a maxlength', function () {
+      characterCount();
+      $('#test-maxlength-hint').text().should.have.string('You have 50 characters remaining');
+    });
+
+    it('should remove the maxlength attribute from the textarea', function () {
+      characterCount();
+      $('#test').should.not.have.property('maxlength');
+    });
+
+  });
+
+  describe('update on input', function () {
+
+    beforeEach(function () {
+      // textarea with 10 maximum characters
+      $('form').append($('<div id="test-group"><textarea name="test" id="test" class="maxlength" maxlength="10"></textarea><span id="test-maxlength-hint" class="form-hint">10 maximum characters</span></div>'));
+      characterCount();
+    });
+
+    it('should have a live character count', function () {
+      $('#test').val('hello');
+      util.triggerEvent(document.getElementById('test'), 'input');
+      $('#test-maxlength-hint').text().should.have.string('You have 5 characters remaining');
+    });
+
+    it('should change the suffix to `too many` when there are too many characters', function () {
+      $('#test').val('tooManyChars');
+      util.triggerEvent(document.getElementById('test'), 'input');
+      $('#test-maxlength-hint').text().should.have.string('You have 2 characters too many');
+    });
+
+    it('should change `characters` to `character` when there is one character remaining or too many', function () {
+      $('#test').val('nineChars');
+      util.triggerEvent(document.getElementById('test'), 'input');
+      $('#test-maxlength-hint').text().should.have.string('You have 1 character remaining');
+    });
+
+    it('should add the error class when user goes over the character limit and revert to the non-error class when the user goes back into the limit', function () {
+      // first go over limit and assert it has error class
+      $('#test').val('tooManyChars');
+      util.triggerEvent(document.getElementById('test'), 'input');
+      $('#test').hasClass('textarea-error').should.be.true;
+      $('#test-maxlength-hint').hasClass('error-message').should.be.true;
+      $('#test-maxlength-hint').hasClass('form-hint').should.be.false;
+
+      // go back into limit and assert it has removed error class
+      $('#test').val('nineChars');
+      util.triggerEvent(document.getElementById('test'), 'input');
+      $('#test').hasClass('textarea-error').should.be.false;
+      $('#test-maxlength-hint').hasClass('form-hint').should.be.true;
+      $('#test-maxlength-hint').hasClass('error-messsage').should.be.false;
+    });
+
+  });
+
+  describe('update on timer for assistive technologies', function () {
+
+    beforeEach(function () {
+      this.clock = sinon.useFakeTimers();
+      $('form').append($('<div id="test-group"><textarea name="test" id="test" class="maxlength" maxlength="10"></textarea><span id="test-maxlength-hint" class="form-hint">10 maximum characters</span></div>'));
+      characterCount();
+    });
+
+    afterEach(function () {
+      this.clock.restore();
+    });
+
+    it('should update the hint message even when the value is directly edited without an input event', function () {
+      $('#test').val('nineChars');
+      $('#test').focus();
+      this.clock.tick(1100);
+      $('#test-maxlength-hint').text().should.have.string('You have 1 character remaining');
+    });
+
+    it('should not update the hint message if the value is the same length and there have been no input events', function () {
+      $('#test').focus();
+      this.clock.tick(1100);
+      $('#test-maxlength-hint').text().should.have.string('You have 10 characters remaining');
+    });
+
+  });
+
+  describe('multiple textareas', function () {
+
+    beforeEach(function () {
+      $('form').append($('<div id="test-group"><textarea name="test" id="test" class="maxlength" maxlength="10"></textarea><span id="test-maxlength-hint" class="form-hint">10 maximum characters</span></div>'));
+      $('form').append($('<div id="test2-group"><textarea name="test2" id="test2" class="maxlength" maxlength="10"></textarea><span id="test2-maxlength-hint" class="form-hint">10 maximum characters</span></div>'));
+      characterCount();
+    });
+
+    it('should only update the hint of the textarea that has been updated', function () {
+      $('#test').val('nineChars');
+      util.triggerEvent(document.getElementById('test'), 'input');
+      $('#test-maxlength-hint').text().should.have.string('You have 1 character remaining');
+      $('#test2-maxlength-hint').text().should.have.string('You have 10 characters remaining');
+    });
+
+    it('should update both hints when both textareas have been updated', function () {
+      $('#test').val('nineChars');
+      $('#test2').val('sixCha');
+      util.triggerEvent(document.getElementById('test'), 'input');
+      util.triggerEvent(document.getElementById('test2'), 'input');
+      $('#test-maxlength-hint').text().should.have.string('You have 1 character remaining');
+      $('#test2-maxlength-hint').text().should.have.string('You have 4 characters remaining');
+    });
+
+  });
+
+});


### PR DESCRIPTION
**What?**
Adds a hint under textareas with the maxlength attribute and counts down how many characters the user has remaining as they type

**Why?**
To improve accessibility as currently there is no message to the user expressing that there is a character limit

**How?**
Removes the maxlength attribute, adds event listener to capture input and event listener to refresh and detect changes from assistive technologies. Updates hint below textarea displaying characters user has remaining 

**Testing?**
Adds tests in character count spec file

**Screenshots**
<img width="608" alt="Screenshot 2020-11-09 at 17 04 05" src="https://user-images.githubusercontent.com/61828376/98572476-96d28e00-22ad-11eb-86e1-06ea2e43d3c5.png">
<img width="616" alt="Screenshot 2020-11-09 at 17 05 13" src="https://user-images.githubusercontent.com/61828376/98572625-bf5a8800-22ad-11eb-9292-88b5bca4eb49.png">



