### PR TITLE
fix: character count message when textarea has content on load

### DIFF
--- a/assets/javascript/character-count.js
+++ b/assets/javascript/character-count.js
@@ -44,9 +44,8 @@ CharacterCount.prototype.handleBlur = function () {
 };
 
 CharacterCount.prototype.init = function() {
-
   // Updates hint to js-enabled message
-  this.$maxlengthHint.innerHTML = 'You have ' + this.maxLength.toString() + ' characters remaining';
+  this.updateCount();
 
   // remove maxLength restriction on element
   this.$textarea.removeAttribute('maxlength');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hof-frontend-toolkit",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hof-frontend-toolkit",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Set of common UI patterns/styles for hof projects",
   "main": "index.js",
   "sass": "assets/stylesheets/app.scss",


### PR DESCRIPTION
## What
Fix bug where text area character count message doesn't account for text content already in the textarea on dom load (e.g. when user has entered text into the field, submitted the form, but a validation error keeps them on the same page).

## Why
So users aren't presented with incorrect info on how many characters they have remaining.

## How
Use updateCount() method when initialising character count, instead of assuming the field is empty.