### PR TITLE
fix: character count was read as year by screen readers

### DIFF
--- a/assets/javascript/character-count.js
+++ b/assets/javascript/character-count.js
@@ -15,7 +15,18 @@ CharacterCount.prototype.updateCount = function() {
     remainderSuffix = ' too many';
   }
 
-  this.$maxlengthHint.innerHTML = 'You have ' + Math.abs(this.maxLength - currentLength).toString() + characterNoun + remainderSuffix;
+  function addCommas(numString) {
+    var rgx = /(\d+)(\d{3})/;
+    while (rgx.test(numString)) {
+      numString = numString.replace(rgx, '$1' + ',' + '$2');
+    }
+    return numString;
+  }
+
+  // format the number with commas separating thousands, so screen readers do not read them as a year
+  var number = addCommas(Math.abs(this.maxLength - currentLength).toString());
+
+  this.$maxlengthHint.innerHTML = 'You have ' + number + characterNoun + remainderSuffix;
 
   if (currentLength >= this.maxLength + 1) {
     helpers.removeClass(this.$maxlengthHint, 'form-hint');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hof-frontend-toolkit",
-  "version": "2.4.1",
+  "version": "2.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hof-frontend-toolkit",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "Set of common UI patterns/styles for hof projects",
   "main": "index.js",
   "sass": "assets/stylesheets/app.scss",

--- a/test/client/spec/spec.character-count.js
+++ b/test/client/spec/spec.character-count.js
@@ -74,6 +74,19 @@ describe('character-count', function () {
 
   });
 
+  describe('high character counts', function() {
+
+    beforeEach(function () {
+      $('form').append($('<div id="test-group"><textarea name="test" id="test" class="maxlength" maxlength="2000"></textarea><span id="test-maxlength-hint" class="form-hint">2000 maximum characters</span></div>'));
+      characterCount();
+    });
+
+    it('should insert commas when character count is 1000 or more, so screen readers do not read the number as a year', function () {
+      $('#test-maxlength-hint').text().should.have.string('You have 2,000 characters remaining');
+    });
+
+  });
+
   describe('update on timer for assistive technologies', function () {
 
     beforeEach(function () {


### PR DESCRIPTION
## What

Update character count helper to insert commas into the character count.

## Why

So that screen readers read the count as a number, rather than a year (e.g. 1956 should be read 'one-thousand-nine-hundred-and-fifty-six', not 'nineteen-fifty-six')